### PR TITLE
[FIX] Added simplejson as requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+simplejson
 pyTelegramBotAPI
 pygal
 cairosvg<2.0.0


### PR DESCRIPTION
When included as installable path it breaks several files at view. Adding simplejson as part of requirement solved this.